### PR TITLE
Fix push new tag only when releasing

### DIFF
--- a/src/dev/dumper.sh
+++ b/src/dev/dumper.sh
@@ -6,7 +6,7 @@
 #   https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
 # Credit:
 #   https://superuser.com/a/1119396
-function sgr() {
+sgr() {
   local codes=${1:-0}
   shift
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -68,7 +68,7 @@ function main::render_steps() {
   echo -e "- Merge the selected branch (${COLOR_YELLOW}$source${COLOR_RESET}) to ${COLOR_YELLOW}$target${COLOR_RESET}"
   echo -e "- Create a tag and release"
   echo -e "- Notify via slack that a new release was created"
-  echo -e "- Merge the target branch (${COLOR_YELLOW}$target${COLOR_RESET}) back to ${COLOR_YELLOW}$develop${COLOR_RESET}"
+  echo -e "- Merge the target (${COLOR_YELLOW}$target${COLOR_RESET}) back to ${COLOR_YELLOW}$develop${COLOR_RESET}"
   echo -e ""
   echo -e "This script must use your local git environment."
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -60,20 +60,19 @@ function main::render_steps() {
   local target=$2
   local develop=$3
 
-  echo "This script will automate the release process and follow the following steps:"
-  echo "- Define the branch to release: $source"
-  echo "- Fetch latest remote changes"
-  echo "- Compare the branch with $target to view the commits that will be released"
-  echo "- Confirm you wish to proceed"
-  echo "- Merge the selected branch to $target"
-  echo "- Create a tag and release"
-  echo "- Notify via slack that a new release was created"
-  echo "- Merge the selected branch back to $develop"
-  echo ""
-  echo "This script must use your local git environment."
+  echo -e "This script will automate the release process and follow the following steps:"
+  echo -e "- Define the branch to release: ${COLOR_YELLOW}$source${COLOR_RESET}"
+  echo -e "- Fetch latest remote changes"
+  echo -e "- Compare the branch with ${COLOR_YELLOW}$target${COLOR_RESET} to view the commits that will be released"
+  echo -e "- Confirm you wish to proceed"
+  echo -e "- Merge the selected branch (${COLOR_YELLOW}$source${COLOR_RESET}) to ${COLOR_YELLOW}$target${COLOR_RESET}"
+  echo -e "- Create a tag and release"
+  echo -e "- Notify via slack that a new release was created"
+  echo -e "- Merge the target branch (${COLOR_YELLOW}$target${COLOR_RESET}) back to ${COLOR_YELLOW}$develop${COLOR_RESET}"
+  echo -e ""
+  echo -e "This script must use your local git environment."
 
   if [[ "$DRY_RUN" == true ]]; then
-    echo -e "${COLOR_YELLOW}--dry-run enabled${COLOR_RESET}"
-    return
+    echo -e "${COLOR_BLUE}--dry-run enabled${COLOR_RESET}"
   fi
 }

--- a/src/release.sh
+++ b/src/release.sh
@@ -34,7 +34,8 @@ function release::create_tag() {
 Changes:
 $changed_files"
 
-  git push origin "$branch_name" --tags --no-verify
+  git push origin "$new_tag" --no-verify
+  git push origin "$branch_name" --no-verify
 }
 
 # shellcheck disable=SC2155


### PR DESCRIPTION


## 🤔 Background

![Screenshot 2024-12-12 at 17 10 45](https://github.com/user-attachments/assets/85aa3b64-7eaa-4a1f-a186-6404053b1a7b)

## 💡 Goal

Do not fail pushing new tag if an older tag is not "on sync". We dont care that much about the old tags, but about the new tag and its code when creating a new release

## 🔖 Changes

Instead of 
```bash
git push origin "$branch_name" --tags --no-verify
```

do this
```bash
git push origin "$branch_name" --no-verify
git push origin "$new_tag" --no-verify
```

## 🖼️ Demo

<img width="1031" alt="Screenshot 2024-12-12 at 17 13 56" src="https://github.com/user-attachments/assets/f544d1db-addb-4197-859b-91f0a8f978c7" />
