### PR TITLE
Do git pull when checkout a branch

### DIFF
--- a/src/git.sh
+++ b/src/git.sh
@@ -42,6 +42,8 @@ function git::force_checkout() {
     git checkout -b "$branch_name" origin/"$branch_name"
   fi
 
+  git::pull_origin
+
   [ -f .git/hooks/post-checkout.bak ] && mv .git/hooks/post-checkout.bak .git/hooks/post-checkout
   git config advice.detachedHead true
 }

--- a/src/git.sh
+++ b/src/git.sh
@@ -8,6 +8,10 @@ function git::fetch_origin() {
   git fetch origin
 }
 
+function git::pull_origin() {
+  git pull origin
+}
+
 function git::changed_files() {
   git diff --name-only "$1".."$2"
 }
@@ -28,7 +32,7 @@ function git::force_checkout() {
   git config advice.detachedHead false
   [ -f .git/hooks/post-checkout ] && mv .git/hooks/post-checkout .git/hooks/post-checkout.bak
 
-  git fetch origin
+  git::fetch_origin
 
   if git rev-parse --verify "$branch_name" >/dev/null 2>&1; then
     # If branch exists locally, force checkout it

--- a/src/release.sh
+++ b/src/release.sh
@@ -35,7 +35,6 @@ Changes:
 $changed_files"
 
   git push origin "$new_tag" --no-verify
-  git push origin "$branch_name" --no-verify
 }
 
 # shellcheck disable=SC2155


### PR DESCRIPTION
### 🔗 Ticket

Closes: https://github.com/Purpose-Green/release/issues/11

## 🤔 Background

When releasing, we had to manually do a git pull from `main` branch. 

## 💡 Goal

Automatically do a git pull to get latest changes on our local branches when checkout another branch.
